### PR TITLE
Improve flights loader: password prompt, server-side throttle, Ctrl-C…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schema/.flights_rowcount.cache

--- a/run_project
+++ b/run_project
@@ -14,7 +14,14 @@ CONN_FLAGS=("$@")
 # Tunables for the parallel flights load. We pre-split flights.csv into NUM_CHUNKS
 # files and feed at most MAX_PARALLEL of them to LOAD DATA LOCAL INFILE at a time.
 NUM_CHUNKS=8
-MAX_PARALLEL=4 # Adjust based on your Cloud Instance CPU/IO limits
+MAX_PARALLEL=4 # Max concurrent LOAD DATA into flights, measured server-side (see throttle below)
+POLL_INTERVAL=3 # Seconds between server-side concurrency checks
+# Canonical flights.csv from the S3 bucket. If the on-disk byte size matches
+# exactly, we trust this row count and skip the ~6 GB scan entirely (even on a
+# fresh checkout). A mismatch (updated/partial download) falls through to a real
+# count + the size+mtime cache, so these are a fast-path seed, never a hard dep.
+EXPECTED_FLIGHTS_SIZE=6456261509
+EXPECTED_FLIGHTS_ROWS=38083735
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -22,11 +29,36 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+# Kill in-flight child processes if the user hits Ctrl-C, so no chunk loads are
+# left running in the background after we exit. Our tree is script -> chunk
+# subshell -> mariadb client, so we kill the subshells AND their mariadb children
+# (killing the subshell alone would orphan, not stop, the mariadb client).
+on_interrupt() {
+    trap - INT TERM
+    echo
+    echo -e "${YELLOW}Interrupted — killing in-flight loads...${NC}" >&2
+    local p
+    for p in $(pgrep -P $$ 2>/dev/null); do
+        pkill -P "$p" 2>/dev/null || true   # mariadb clients (grandchildren)
+        kill "$p" 2>/dev/null || true        # the chunk subshell / child
+    done
+    exit 130
+}
+trap on_interrupt INT TERM
+
 get_filesize() {
     if stat -f%z "$1" >/dev/null 2>&1; then
         stat -f%z "$1" # BSD/macOS
     else
         stat -c%s "$1" # GNU/Linux
+    fi
+}
+
+get_mtime() {
+    if stat -f%m "$1" >/dev/null 2>&1; then
+        stat -f%m "$1" # BSD/macOS
+    else
+        stat -c%Y "$1" # GNU/Linux
     fi
 }
 
@@ -103,9 +135,42 @@ load_flights_chunk() {
 
 FLIGHTS_LOAD_COLUMNS="(\`year\`, \`month\`, \`day\`, \`day_of_week\`, \`fl_date\`, \`carrier\`, \`tail_num\`, \`fl_num\`, \`origin\`, \`dest\`, \`crs_dep_time\`, \`dep_time\`, \`dep_delay\`, \`taxi_out\`, \`wheels_off\`, \`wheels_on\`, \`taxi_in\`, \`crs_arr_time\`, \`arr_time\`, \`arr_delay\`, \`cancelled\`, \`cancellation_code\`, \`diverted\`, \`crs_elapsed_time\`, \`actual_elapsed_time\`, \`air_time\`, \`distance\`, \`carrier_delay\`, \`weather_delay\`, \`nas_delay\`, \`security_delay\`, \`late_aircraft_delay\`, @unused_trailing_field)"
 
+# running_flights_loads: how many LOAD DATA ... INTO flights statements this user
+# currently has executing on the server. Drives the throttle below — counting real
+# server activity instead of local bash jobs (which also count blocked/retrying ones).
+# Defaults to 0 if the probe fails so a transient error can't deadlock the loop.
+running_flights_loads() {
+    "$MARIADB_BIN" "${CONN_FLAGS[@]}" --connect-timeout=10 -N -B -e \
+        "SELECT COUNT(*) FROM information_schema.processlist
+         WHERE user = SUBSTRING_INDEX(CURRENT_USER(),'@',1)
+           AND command = 'Query'
+           AND info LIKE 'LOAD DATA%INTO TABLE flights%'" 2>/dev/null || echo 0
+}
+
 if [ ${#CONN_FLAGS[@]} -eq 0 ]; then
     echo -e "${RED}Error: No connection flags provided.${NC}"
     exit 1
+fi
+
+# --- Password handling ---
+# This script runs the mariadb client many times. A bare `-p` makes the client
+# prompt on every invocation, so prompt once here and reuse the value as
+# `-p<password>` on all subsequent commands (CONN_FLAGS is passed to each).
+PASSWORD_SET=0
+FILTERED_FLAGS=()
+for flag in "${CONN_FLAGS[@]}"; do
+    case "$flag" in
+        -p?*|--password=*) PASSWORD_SET=1; FILTERED_FLAGS+=("$flag") ;;
+        -p|--password)     ;; # bare flag, no value — drop it; we prompt below
+        *)                 FILTERED_FLAGS+=("$flag") ;;
+    esac
+done
+CONN_FLAGS=("${FILTERED_FLAGS[@]}")
+
+if [[ "$PASSWORD_SET" -eq 0 ]]; then
+    read -r -s -p "Enter MariaDB Cloud password: " DB_PASSWORD
+    echo
+    CONN_FLAGS+=("-p${DB_PASSWORD}")
 fi
 
 # 1. Test Connection (fast pre-flight so we don't wait minutes on a silent TCP timeout)
@@ -191,10 +256,35 @@ for TABLE in airports airlines; do
 done
 
 # Configuration
-TOTAL_ROWS=$(wc -l < "${SCHEMA_DIR}/flights.csv" | tr -d ' ')
+FLIGHTS_SIZE=$(get_filesize "${SCHEMA_DIR}/flights.csv")
+FLIGHTS_MTIME=$(get_mtime "${SCHEMA_DIR}/flights.csv")
+ROWCOUNT_CACHE="${SCHEMA_DIR}/.flights_rowcount.cache"
+
+# Counting rows means reading all 6 GB, so cache the result keyed on size+mtime
+# (both instant to read) and skip the scan when flights.csv hasn't changed.
+# Cache line format: "<size> <mtime> <rows>".
+TOTAL_ROWS=""
+ROWCOUNT_SOURCE=""
+if [[ "$FLIGHTS_SIZE" == "$EXPECTED_FLIGHTS_SIZE" ]]; then
+    TOTAL_ROWS="$EXPECTED_FLIGHTS_ROWS"
+    ROWCOUNT_SOURCE="known canonical file"
+elif [[ -f "$ROWCOUNT_CACHE" ]]; then
+    read -r C_SIZE C_MTIME C_ROWS < "$ROWCOUNT_CACHE" || true
+    if [[ "${C_SIZE:-}" == "$FLIGHTS_SIZE" && "${C_MTIME:-}" == "$FLIGHTS_MTIME" ]]; then
+        TOTAL_ROWS="$C_ROWS"
+        ROWCOUNT_SOURCE="cached"
+    fi
+fi
+if [[ -n "$TOTAL_ROWS" ]]; then
+    echo -e "${BLUE}flights.csv unchanged ($(format_bytes "$FLIGHTS_SIZE"), ${ROWCOUNT_SOURCE}), row count:${NC} ${GREEN}${TOTAL_ROWS}${NC}"
+else
+    echo -ne "${BLUE}Counting rows in flights.csv ($(format_bytes "$FLIGHTS_SIZE"))...${NC} "
+    TOTAL_ROWS=$(wc -l < "${SCHEMA_DIR}/flights.csv" | tr -d ' ')
+    echo -e "${GREEN}${TOTAL_ROWS}${NC}"
+    echo "$FLIGHTS_SIZE $FLIGHTS_MTIME $TOTAL_ROWS" > "$ROWCOUNT_CACHE"
+fi
 DATA_ROWS=$(( TOTAL_ROWS - 1 )) # exclude header
 LINES_PER_CHUNK=$(( (DATA_ROWS + NUM_CHUNKS - 1) / NUM_CHUNKS ))
-FLIGHTS_SIZE=$(get_filesize "${SCHEMA_DIR}/flights.csv")
 
 echo
 echo -e "${BLUE}Pre-splitting flights.csv (${TOTAL_ROWS} rows, $(format_bytes "$FLIGHTS_SIZE")) into ${NUM_CHUNKS} chunks of up to ${YELLOW}${LINES_PER_CHUNK} rows${BLUE}...${NC}"
@@ -217,6 +307,12 @@ for (( i=0; i<ACTUAL_CHUNKS; i++ )); do
     CHUNK_NAME=$(basename "$CHUNK_FILE")
     CHUNK_NUM=$(( i + 1 ))
 
+    # Throttle on real server activity: block until this user has fewer than
+    # MAX_PARALLEL LOAD DATA statements running against flights, then fire.
+    while (( $(running_flights_loads) >= MAX_PARALLEL )); do
+        sleep "$POLL_INTERVAL"
+    done
+
     (
         CHUNK_START=$(date +%s)
         echo -e "${YELLOW}Starting flights chunk ${CHUNK_NUM}/${ACTUAL_CHUNKS} (${CHUNK_NAME}, $(format_bytes "$(get_filesize "$CHUNK_FILE")"))${NC}"
@@ -228,12 +324,10 @@ for (( i=0; i<ACTUAL_CHUNKS; i++ )); do
         fi
     ) &
 
-    # Throttle to MAX_PARALLEL concurrent subshells. `while` (not `if`) handles
-    # the case where multiple subshells finish in close succession: wait -n only
-    # reaps one per call, but the loop re-checks the live count each iteration.
-    while (( $(jobs -r | wc -l) >= MAX_PARALLEL )); do
-        wait -n || true
-    done
+    # Let the load we just fired register in the processlist before the next
+    # iteration polls, so a burst of fast-connecting chunks can't overshoot
+    # MAX_PARALLEL between the gate check and the load appearing server-side.
+    sleep "$POLL_INTERVAL"
 done
 wait
 


### PR DESCRIPTION
… cleanup, row-count cache

- Prompt once for the MariaDB Cloud password when only a bare `-p` (or none) is passed, then reuse it as `-p<password>` across all client invocations instead of re-prompting on every command.
- Throttle the parallel flights load on real server activity: poll information_schema.processlist for this user's running LOAD DATA into flights and gate new chunks on MAX_PARALLEL, replacing the bash `jobs`/`wait -n` count (which also counted blocked/retrying subshells). Adds POLL_INTERVAL.
- Trap Ctrl-C (INT/TERM) to kill in-flight chunk subshells and their mariadb clients, so nothing is left loading in the background after exit.
- Narrate the previously-silent ~6 GB row count, and cache it: a baked-in size/row-count seed for the canonical S3 file skips the scan even on a fresh checkout, with a size+mtime cache fallback for other unchanged files.
- gitignore the row-count cache file.